### PR TITLE
[darwin] Fix fetchzip call by using https not http

### DIFF
--- a/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/adv_cmds/boot.nix
@@ -11,7 +11,7 @@
 # the more recent adv_cmds release is used for everything else in this package
 
 let recentAdvCmds = fetchzip {
-  url = "http://opensource.apple.com/tarballs/adv_cmds/adv_cmds-158.tar.gz";
+  url = "https://opensource.apple.com/tarballs/adv_cmds/adv_cmds-158.tar.gz";
   sha256 = "0z081kcprzg5jcvqivfnwvvv6wfxzkjg2jc2lagsf8c7j7vgm8nn";
 };
 


### PR DESCRIPTION
Fetchzip/fetchurl don't work with the previous hardcoded URL scheme. This may be due to changes on AWS/S3.